### PR TITLE
Upgrade Spring Boot version and update .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -240,3 +240,7 @@ gradle-app.setting
 *.hprof
 
 # End of https://www.toptal.com/developers/gitignore/api/java,gradle,intellij+all,macos,windows
+
+# Configuration files
+*.properties
+*.yml

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.1.5'
+	id 'org.springframework.boot' version '3.2.0'
 	id 'io.spring.dependency-management' version '1.1.0'
 	id 'jacoco'
 }
@@ -54,6 +54,9 @@ dependencies {
 	// Monitoring
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
+
+	// H2 Database (for testing)
+	testImplementation 'com.h2database:h2'
 }
 
 dependencyManagement {


### PR DESCRIPTION
Spring Boot 3.1.5 버전이 명시된 Spring Cloud 버전과 호환되지 않아서 3.2.0으로 업그레이드했습니다.