### PR TITLE
Implement OAuth2 login with Google, Kakao, and Naver

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,9 @@ dependencies {
 
 	// H2 Database (for testing)
 	testImplementation 'com.h2database:h2'
+
+	// OAuth2 Client
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 }
 
 dependencyManagement {

--- a/src/main/java/com/neon/tonari/config/OAuth2LoginConfig.java
+++ b/src/main/java/com/neon/tonari/config/OAuth2LoginConfig.java
@@ -1,0 +1,24 @@
+package com.neon.tonari.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+import static org.springframework.security.config.Customizer.withDefaults;
+
+@Configuration
+@EnableWebSecurity
+public class OAuth2LoginConfig {
+
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .authorizeHttpRequests(authorizeRequests ->
+                        authorizeRequests
+                                .requestMatchers("/", "/login**", "/oauth2/**", "/webjars/**").permitAll()
+                                .anyRequest().authenticated()
+                )
+                .oauth2Login(withDefaults());
+        return http.build();
+    }
+}


### PR DESCRIPTION
This PR sets up OAuth2 login using Google, Kakao, and Naver for the Tonari backend service. It includes configuration for OAuth2 clients and Spring Security setup.